### PR TITLE
Improve logging of unknown errors

### DIFF
--- a/defaultErrorHandler.js
+++ b/defaultErrorHandler.js
@@ -1,3 +1,4 @@
+const util = require('util');
 const { INTERNAL_SERVER_ERROR, BAD_REQUEST, getStatusText } = require('http-status-codes');
 const { ValidationError } = require('yup');
 

--- a/defaultErrorHandler.js
+++ b/defaultErrorHandler.js
@@ -14,6 +14,6 @@ module.exports = ({ err, res }) => {
   } else {
     res.status(INTERNAL_SERVER_ERROR).send({ message: getStatusText(INTERNAL_SERVER_ERROR) });
     // eslint-disable-next-line no-console
-    console.error(util.inspect(err, true, 5));
+    console.error(util.inspect(err, false, 5));
   }
 };

--- a/defaultErrorHandler.js
+++ b/defaultErrorHandler.js
@@ -13,6 +13,6 @@ module.exports = ({ err, res }) => {
   } else {
     res.status(INTERNAL_SERVER_ERROR).send({ message: getStatusText(INTERNAL_SERVER_ERROR) });
     // eslint-disable-next-line no-console
-    console.log(err.stack);
+    console.error(util.inspect(err, true, 5));
   }
 };


### PR DESCRIPTION
- Print to `stderr` instead of stdout.
- Print error properties alongside the stack.

Closes #4 